### PR TITLE
Fix for Network Server Policy with Windows Server 2016

### DIFF
--- a/src/EAPPacket.php
+++ b/src/EAPPacket.php
@@ -72,6 +72,12 @@ class EAPPacket
     {
         // TODO: validate incoming packet better
 
+        // In some case, the packet is an array structured like this :
+        //   $packet[0] = <attribute ID>
+        //   $packed[1] = <data>
+        if(is_array($packet))
+            $packet = $packet[1];
+
         $p = new self();
         $p->code = ord($packet[0]);
         $p->id   = ord($packet[1]);

--- a/src/Radius.php
+++ b/src/Radius.php
@@ -598,6 +598,12 @@ class Radius
         }
 
         $temp = null;
+        
+        // In some case, the value is an array structured like this :
+        //   $packet[0] = <attribute ID>
+        //   $packed[1] = <data>
+        if(is_array($value))
+            $value = $value[1];
 
         if (isset($this->attributesInfo[$type])) {
             switch ($this->attributesInfo[$type][1]) {


### PR DESCRIPTION
Hi,

I have installed a Windows Server 2016 server and configured the Network Server Policy to enable RADIUS with EAP-MSCHAPv2 authentification method for web applications in my network.

When testing your library, I encountered problems because some returned values were arrays and not strings. By debugging, I found that the strings were just encapsulated in a array with the following structure : [0] : attribute id and [1] : data in a string.

I made the two changes listed below and now everything works perfectly.

Thank you for your work