### PR TITLE
Add support for multibyte string

### DIFF
--- a/lib/Pear_CHAP.php
+++ b/lib/Pear_CHAP.php
@@ -240,8 +240,8 @@ class Crypt_CHAP_MSv1 extends Crypt_CHAP
     {
         $uni = '';
         $str = (string) $str;
-        for ($i = 0; $i < strlen($str); $i++) {
-            $a = ord($str{$i}) << 8;
+        for ($i = 0; $i < mb_strlen($str); $i++) {
+            $a = mb_ord(mb_substr($str,$i,1)) << 8;
             $uni .= sprintf("%X", $a);
         }
         return pack('H*', $uni);


### PR DESCRIPTION
Issue #5 : Cannot authentificate with a specific special character in password.
Add support for multibyte string (https://www.php.net/manual/en/book.mbstring.php) in str2unicode function (Pear_CHAP.php).
Function interprets all characters with 1 byte (basic UTF-8) while special characters are encoded with more than 1 byte (see column UTF-8(hex.) in https://www.utf8-chartable.de/unicode-utf8-table.pl?names=-&unicodeinhtml=hex).