### PR TITLE
2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ matrix:
       dist: trusty
     - php: 7.2
       dist: trusty
+    - php: 7.3
+      dist: bionic
+    - php: 7.4
+      dist: bionic
 
 before_install:
     - composer require --dev --no-update phpunit/phpunit ^4.8

--- a/composer.json
+++ b/composer.json
@@ -5,10 +5,10 @@
     "keywords": ["radius","authentication","authorization","pap","chap","ms-chap","ms-chap v2","rfc2865","rfc1994","rfc2284","rfc2869","rfc2759"],
     "homepage": "https://github.com/dapphp/radius",
     "require": {
-        "php": ">=5.3"
+        "php": ">=5.3 || <= 7.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.8"
+        "phpunit/phpunit": "^4.8"
     },
     "suggest": {
         "ext-openssl": "To support hashing required by Pear_CHAP"


### PR DESCRIPTION
This is likely to be the last release in the 2.x branch. Going forward, use the 3.0 branch for PHP 8.0+ or PHP 7.3/7.4.

* Tag release 2.5.5 - Fixes #16 
* Update composer.json to require PHP >= 5.3 || PHP <= 7.4
* Update Travis config to test PHP 7.3 and 7.4