### PR TITLE
Respect pre-set Service-Type in accessRequest

### DIFF
--- a/src/Radius.php
+++ b/src/Radius.php
@@ -1681,7 +1681,7 @@ class Radius
      * @param string $username  Username to authenticate as
      * @param string $password  Password to authenticate with using PAP
      * @param int    $timeout   The timeout (in seconds) to wait for a response packet
-     * @param string $state     The state of the request (default is Service-Type=1)
+     * @param string $state     The state of the request (default is Service-Type=1 unless already set)
      * @return boolean          true if the server sent an Access-Accept packet, false otherwise
      */
     public function accessRequest($username = '', $password = '', $timeout = 0, $state = null)
@@ -1701,7 +1701,9 @@ class Radius
         if ($state !== null) {
             $this->setAttribute(24, $state);
         } else {
-            $this->setAttribute(6, 1); // 1=Login
+			if ($this->getAttributesToSend(6) === null) {
+				$this->setAttribute(6, 1); // 1=Login
+			}
         }
 
         if (intval($timeout) > 0) {


### PR DESCRIPTION
## Summary

`accessRequest()` currently overwrites **Service-Type** with `Login-User` when `$state` is `null`.  
This makes it impossible for callers to set `Service-Type` explicitly (e.g., `Authenticate-Only`).

This change ensures the default `Service-Type = Login-User` is only applied when the caller has **not** already set the attribute.

---

## Problem

- When `$state` is `null`, `accessRequest()` always executes `setAttribute(6, 1)`  
  (i.e. `Service-Type = Login-User`)
- This overrides any caller-provided `Service-Type` (e.g. `Authenticate-Only`)
- As a result, FreeRADIUS receives an incorrect value

---

## Change

- In `accessRequest()`, only set `Service-Type = Login-User` **if Service-Type is not already present** in the outgoing attributes

---

## Behavior

### Before

- Caller sets `Service-Type = Authenticate-Only`
- `accessRequest()` overwrites it with `Login-User`

### After

- Caller sets `Service-Type = Authenticate-Only`
- `accessRequest()` preserves it

---

## Files Changed

- `src/Radius.php`

---

## Testing

- Verified against a production FreeRADIUS server  
  → `Service-Type` remains `Authenticate-Only` when explicitly set by caller

---

## Notes

This keeps the default behavior unchanged for callers who don’t set `Service-Type`,  
while unblocking explicit `Service-Type` use cases.
